### PR TITLE
Fixed child ordering in many-to-many relationships

### DIFF
--- a/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/src/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1994,6 +1994,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
 	        
 	        for (Contentlet c : related.getRecords()) {
 	            if (child) {
+	                for (Tree currentTree: contentParents) {
+				if (currentTree.getRelationType().equals(rel.getRelationTypeValue()) && c.getIdentifier().equals(currentTree.getParent())) {
+					positionInParent = currentTree.getTreeOrder();
+				}
+			}
+
 	                newTree = new Tree(c.getIdentifier(), contentlet.getIdentifier(), rel.getRelationTypeValue(), positionInParent);
 	            } else {
 	                newTree = new Tree(contentlet.getIdentifier(), c.getIdentifier(), rel.getRelationTypeValue(), treePosition);


### PR DESCRIPTION
When updating one of multiple child contentlets in a many-to-many relationship the order was mixed up. The reason was that the treeOrder of the child was always set to "1". This seems to have broken as a result of the fix for #4370 (commit f83619b152e02863e730931aa8959cd600446824).

The error could be reproduced in the dotCMS demo system (http://demo.dotcms.com/).

1. Create a parent Structure A and a child Structure B
2. Add a Many to Many Relationship between Structures
3. Add Relationship field on child Structure B
4. Create a content for parent Structure A and try to relate Structure B contents (4 contents).
5. Observe the order of the child contents
6. Modify the third child (Structure B) and Save&Publish
7. You will see that the child objects' order has been messed up